### PR TITLE
Add simple web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # plemiona
-plemiona
+
+This repository contains small helper scripts for the browser game *Plemiona*.
+
+## Web interface
+
+A simple interface is available inside the `web/` directory. To use it, open
+`web/index.html` in your browser. No additional server is required – just open
+the file locally and interact with the UI.

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,104 @@
+function addListItem(list, text) {
+  const li = document.createElement('li');
+  li.textContent = text;
+  list.appendChild(li);
+}
+
+document.getElementById('addPlayer').addEventListener('click', () => {
+  const name = document.getElementById('playerName').value.trim();
+  if (name) {
+    addListItem(document.getElementById('playerList'), name);
+    document.getElementById('playerName').value = '';
+  }
+});
+
+document.getElementById('addVillage').addEventListener('click', () => {
+  const coord = document.getElementById('villageCoord').value.trim();
+  if (coord) {
+    addListItem(document.getElementById('villageList'), coord);
+    document.getElementById('villageCoord').value = '';
+  }
+});
+
+async function runPlanCheck(input) {
+  const lines = input.trim().split('\n');
+  const planned = [];
+  let currentPlayer = null;
+
+  for (let line of lines) {
+    line = line.trim();
+    if (!line) continue;
+    if (/^[A-ZĄĆĘŁŃÓŚŹŻa-z]/.test(line) && !line.includes('http')) {
+      currentPlayer = line;
+      continue;
+    }
+    const match = line.match(/village=(\d+).*?target=(\d+)/);
+    if (match) {
+      planned.push({
+        player: currentPlayer || 'Nieznany',
+        from: match[1],
+        to: match[2],
+        key: `${match[1]}->${match[2]}`
+      });
+    }
+  }
+
+  if (planned.length === 0) {
+    alert('Nie znaleziono żadnych rozkazów w danych z planera.');
+    return null;
+  }
+
+  // Poniższy kod wykorzystuje game_data tak jak oryginalny skrypt.
+  const res = await fetch(`https://${game_data.world}.plemiona.pl/map/village.txt`);
+  const txt = await res.text();
+  const myVillageIDs = [];
+  txt.trim().split('\n').forEach(line => {
+    const [id, , , , owner] = line.split(',');
+    if (owner == game_data.player.id) {
+      myVillageIDs.push(parseInt(id));
+    }
+  });
+
+  const sent = new Set();
+  for (const id of myVillageIDs) {
+    const url = `https://${game_data.world}.plemiona.pl/game.php?village=${id}&screen=info_village&id=${id}`;
+    try {
+      const r = await fetch(url);
+      const html = await r.text();
+      const div = document.createElement('div');
+      div.innerHTML = html;
+      const section = div.querySelector('#commands_outgoings');
+      if (!section) continue;
+      section.querySelectorAll(".command-row a[href*='village='][href*='target=']").forEach(a => {
+        const m = a.href.match(/village=(\d+).*?target=(\d+)/);
+        if (m) sent.add(`${m[1]}->${m[2]}`);
+      });
+    } catch (err) {
+      console.warn(`Błąd pobierania rozkazów z wioski ${id}`, err);
+    }
+    await new Promise(r => setTimeout(r, 200));
+  }
+
+  const stats = {};
+  planned.forEach(({ player, key }) => {
+    if (!stats[player]) stats[player] = { total: 0, sent: 0, missing: 0 };
+    stats[player].total++;
+    if (sent.has(key)) stats[player].sent++;
+    else stats[player].missing++;
+  });
+  return stats;
+}
+
+document.getElementById('processPlan').addEventListener('click', async () => {
+  const input = document.getElementById('planInput').value;
+  if (!input) return alert('Brak danych!');
+  const stats = await runPlanCheck(input);
+  if (!stats) return;
+  const table = document.getElementById('resultTable');
+  table.innerHTML = '<tr><th>Gracz</th><th>Do wysłania</th><th>Wysłane</th><th>Nie wysłane</th></tr>';
+  Object.entries(stats).forEach(([player, st]) => {
+    const row = document.createElement('tr');
+    row.innerHTML = `<td>${player}</td><td>${st.total}</td><td>${st.sent}</td><td>${st.missing}</td>`;
+    table.appendChild(row);
+  });
+});

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Plemiona Planer Tool</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Plemiona Planer Tool</h1>
+  <div id="controls">
+    <section id="players">
+      <h2>Players</h2>
+      <input id="playerName" placeholder="Add player">
+      <button id="addPlayer">Add</button>
+      <ul id="playerList"></ul>
+    </section>
+    <section id="villages">
+      <h2>Villages</h2>
+      <input id="villageCoord" placeholder="123|456">
+      <button id="addVillage">Add</button>
+      <ul id="villageList"></ul>
+    </section>
+    <section id="commands">
+      <h2>Planer Data</h2>
+      <textarea id="planInput" rows="10" placeholder="Paste data from plemiona-planer.pl"></textarea>
+      <button id="processPlan">Process</button>
+    </section>
+  </div>
+  <section id="results">
+    <h2>Summary</h2>
+    <table id="resultTable"></table>
+  </section>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,8 @@
+body { font-family: Arial, sans-serif; margin: 20px; background: #f2f2f2; }
+h1 { text-align: center; }
+#controls { display: flex; flex-wrap: wrap; gap: 20px; justify-content: space-around; }
+section { background: #fff; padding: 10px; border-radius: 4px; width: 30%; min-width: 250px; box-shadow: 0 0 6px rgba(0,0,0,0.1); }
+ul { list-style: none; padding: 0; }
+#results { margin-top: 20px; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid #ccc; padding: 4px 8px; }


### PR DESCRIPTION
## Summary
- add `web/` directory with index.html, styles.css and app.js
- move script logic into `app.js` for browser usage
- provide page layout for players, villages and planner data
- document how to open the new UI locally

## Testing
- `node -c web/app.js`
- `node -c zliczanie_fejkow.js`


------
https://chatgpt.com/codex/tasks/task_e_686aa211981883218eeb68f177ccfe2e